### PR TITLE
Fail on subtest failure

### DIFF
--- a/tests/test_subtests.py
+++ b/tests/test_subtests.py
@@ -32,7 +32,7 @@ class TestFixture:
         expected_lines += [
             "* test_foo [[]custom[]] (i=1) *",
             "* test_foo [[]custom[]] (i=3) *",
-            "* 3 failed, 0 passed in *",
+            "* 2 failed, 0 passed in *",
         ]
         result.stdout.fnmatch_lines(expected_lines)
 
@@ -64,7 +64,7 @@ class TestFixture:
         expected_lines += [
             "* test_foo [[]custom[]] (i=1) *",
             "* test_foo [[]custom[]] (i=3) *",
-            "* 3 failed, 0 passed in *",
+            "* 2 failed, 0 passed in *",
         ]
         result.stdout.fnmatch_lines(expected_lines)
 
@@ -114,9 +114,9 @@ class TestFixture:
             "E*assert (2 * 2) == 5",
             "*: AssertionError",
             "*_ test_skip_after_failed_subtest_py _*",
-            "E*pytest_subtests.SubTestFailed: Failed subtests: 1",
-            "*: SubTestFailed",
-            "* 2 failed in *",
+            "Failed subtests: 1",
+            # TODO consider reporting of skip as well
+            "* 1 failed in *",
         ]
         result.stdout.fnmatch_lines(expected_lines)
 
@@ -197,7 +197,7 @@ class TestSubTest:
                     "E  * AssertionError: 1 != 0",
                     "* T.test_foo [[]custom[]] (i=3) *",
                     "E  * AssertionError: 1 != 0",
-                    "* 3 failed in *",
+                    "* 2 failed in *",
                 ]
             )
 
@@ -242,7 +242,7 @@ class TestSubTest:
                     "E  * AssertionError: 1 != 0",
                     "* T.test_foo [[]custom[]] (i=3) *",
                     "E  * AssertionError: 1 != 0",
-                    "* 3 failed in *",
+                    "* 2 failed in *",
                 ]
             )
 


### PR DESCRIPTION
Avoid confusion with tests having failed subtests accounted as passed.
    
- Store failed subtest count as an Item attribute.
- Force additional exception for passed or skipped
  tests if some failures happened in subtests.
    
Accounting and reporting are not ideal:
    
- Count of failed tests is incremented once more.
- Since all subtest exception are reported earlier, it is impossible
  to make some of them main failure reason.

Alleviate #11 a bit.