### PR TITLE
Failed subtests make test failed - 2

### DIFF
--- a/pytest_subtests.py
+++ b/pytest_subtests.py
@@ -8,20 +8,14 @@ from _pytest._code import ExceptionInfo
 from _pytest.capture import CaptureFixture
 from _pytest.capture import FDCapture
 from _pytest.capture import SysCapture
+from _pytest.outcomes import Failed
 from _pytest.outcomes import OutcomeException
 from _pytest.reports import TestReport
 from _pytest.runner import CallInfo
 from _pytest.unittest import TestCaseFunction
 
-if sys.version_info[:2] < (3, 7):
 
-    @contextmanager
-    def nullcontext():
-        yield
-
-
-else:
-    from contextlib import nullcontext
+_ATTR_SUBREPORTS = "_subtests_reports"
 
 
 @attr.s
@@ -77,7 +71,7 @@ def _addSubTest(self, test_case, test, exc_info):
         call_info = CallInfo(None, ExceptionInfo(exc_info), 0, 0, when="call")
         sub_report = SubTestReport.from_item_and_call(item=self, call=call_info)
         sub_report.context = SubTestContext(msg, dict(test.params))
-        self.ihook.pytest_runtest_logreport(report=sub_report)
+        _push_report(self, sub_report)
 
 
 def pytest_configure(config):
@@ -94,18 +88,11 @@ def pytest_unconfigure():
 
 @pytest.fixture
 def subtests(request):
-    capmam = request.node.config.pluginmanager.get_plugin("capturemanager")
-    if capmam is not None:
-        suspend_capture_ctx = capmam.global_and_fixture_disabled
-    else:
-        suspend_capture_ctx = nullcontext
-    yield SubTests(request.node.ihook, suspend_capture_ctx, request)
+    yield SubTests(request)
 
 
 @attr.s
 class SubTests(object):
-    ihook = attr.ib()
-    suspend_capture_ctx = attr.ib()
     request = attr.ib()
 
     @property
@@ -161,11 +148,8 @@ class SubTests(object):
         call_info = CallInfo(None, exc_info, start, stop, when="call")
         sub_report = SubTestReport.from_item_and_call(item=self.item, call=call_info)
         sub_report.context = SubTestContext(msg, kwargs.copy())
-
         captured.update_report(sub_report)
-
-        with self.suspend_capture_ctx():
-            self.ihook.pytest_runtest_logreport(report=sub_report)
+        _push_report(self.item, sub_report)
 
 
 @attr.s
@@ -188,3 +172,102 @@ def pytest_report_to_serializable(report):
 def pytest_report_from_serializable(data):
     if data.get("_report_type") == "SubTestReport":
         return SubTestReport._from_json(data)
+
+
+def _push_report(item, report):
+    if not hasattr(item, _ATTR_SUBREPORTS):
+        setattr(item, _ATTR_SUBREPORTS, [])
+    queue = getattr(item, _ATTR_SUBREPORTS)
+    queue.append(report)
+
+
+def _get_subreports(item):
+    return getattr(item, _ATTR_SUBREPORTS, None)
+
+
+class SubTestFailure(Exception):
+    """Container to pass values between ``pytest_runtest_call`` and ``pytest_runtest_makereport``
+
+    Allows to generate correct ``CallInfo`` after ``pytest.skip()``
+    and to use subtest failure report as the test result.
+    """
+
+    def __init__(self, count, report, exc_info):
+        # message for the case of unexpectedly skipped pytest_runtest_makereport
+        super(SubTestFailure, self).__init__(
+            "Subtest failures: {}".format(count), count
+        )
+        self.report = report
+        self.outcome_excinfo = ExceptionInfo(exc_info) if exc_info is not None else None
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_call(item):
+    """Put subtest exception to outcome of otherwise passed test
+
+    It causes reorder of subtest results if last ones are successful.
+    Failure becomes the latest result.
+    """
+    outcome = yield
+    report_list = _get_subreports(item)
+    if not report_list:
+        return
+
+    outcome_exc_info = None
+    try:
+        outcome.get_result()
+    except (Exception, Failed):
+        # FIXME XFailed is inherited from Failed
+        return
+    except OutcomeException:
+        outcome_exc_info = sys.exc_info()
+
+    failure_report = None
+    i_failure = -1
+    for i, report in enumerate(reversed(report_list)):
+        if report.outcome == "failed":
+            i_failure, failure_report = i, report
+            break
+
+    if failure_report is None:
+        return
+
+    try:
+        raise SubTestFailure(len(report_list), failure_report, outcome_exc_info)
+    except SubTestFailure:
+        outcome._excinfo = sys.exc_info()
+        report_list.pop(-i_failure - 1)
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_runtest_makereport(item, call):
+    """Log subtest reports
+
+    If test failed, returns nothing to transfer control to default hook.
+    In the case of failed subtests, "pass" result of whole test is ignored,
+    "skip" is logged and latest subtest failure becomes the return value.
+    """
+    if call.when != "call":
+        return
+
+    try:
+        report_list = _get_subreports(item)
+        if report_list is None:
+            return
+        for report in report_list:
+            item.ihook.pytest_runtest_logreport(report=report)
+
+        excinfo = call.excinfo
+        result_report = None
+        if excinfo is not None and isinstance(excinfo.value, SubTestFailure):
+            exception = excinfo.value
+            result_report = exception.report
+            if exception.outcome_excinfo is not None:
+                test_call_info = attr.evolve(call, excinfo=exception.outcome_excinfo)
+                report = TestReport.from_item_and_call(item=item, call=test_call_info)
+                item.ihook.pytest_runtest_logreport(report=report)
+
+        return result_report
+    finally:
+        if hasattr(item, _ATTR_SUBREPORTS):
+            delattr(item, _ATTR_SUBREPORTS)


### PR DESCRIPTION
A test with failed subtests reached its finish is not accounted as
passed.  Failure and skip counters are incremented by the number
subtests having similar result.

- Collect subtest reports in an `Item` attribute
- Choose if subtest should be test failure reason in
  `pytest_runtest_call` and wrap report into a dedicated exception.
- In `pytest_runtest_makereport` log subtest reports,
  low priority non-successful rest outcome (skip)
  and return subtest failure report unwrapped from the exception.

Drawbacks:

- Distorted order of subtest results. Failure is moved to the end
  even it was followed by some passed or skipped subtests.
- In no capture mode reports are logged after output,
  so it may be hard to guess their relation.