### PR TITLE
Explicit hint to subtests in progress and summary

### DIFF
--- a/pytest_subtests.py
+++ b/pytest_subtests.py
@@ -188,3 +188,17 @@ def pytest_report_to_serializable(report):
 def pytest_report_from_serializable(data):
     if data.get("_report_type") == "SubTestReport":
         return SubTestReport._from_json(data)
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_report_teststatus(report):
+    if report.when != "call" or not isinstance(report, SubTestReport):
+        return
+
+    outcome = report.outcome
+    if report.passed:
+        return outcome, ",", "SUBPASS"
+    elif report.skipped:
+        return outcome, "-", "SUBSKIP"
+    elif outcome == "failed":
+        return outcome, "u", "SUBFAIL"

--- a/tests/test_subtests.py
+++ b/tests/test_subtests.py
@@ -41,11 +41,11 @@ class TestFixture:
             result = testdir.runpytest("-v")
             expected_lines = [
                 "*collected 1 item",
-                "test_simple_terminal_verbose.py::test_foo PASSED *100%*",
-                "test_simple_terminal_verbose.py::test_foo FAILED *100%*",
-                "test_simple_terminal_verbose.py::test_foo PASSED *100%*",
-                "test_simple_terminal_verbose.py::test_foo FAILED *100%*",
-                "test_simple_terminal_verbose.py::test_foo PASSED *100%*",
+                "test_simple_terminal_verbose.py::test_foo SUBPASS *100%*",
+                "test_simple_terminal_verbose.py::test_foo SUBFAIL *100%*",
+                "test_simple_terminal_verbose.py::test_foo SUBPASS *100%*",
+                "test_simple_terminal_verbose.py::test_foo SUBFAIL *100%*",
+                "test_simple_terminal_verbose.py::test_foo SUBPASS *100%*",
                 "test_simple_terminal_verbose.py::test_foo PASSED *100%*",
             ]
         else:
@@ -168,8 +168,8 @@ class TestSubTest:
                 result = testdir.runpytest(simple_script, "-v")
                 expected_lines = [
                     "*collected 1 item",
-                    "test_simple_terminal_verbose.py::T::test_foo FAILED *100%*",
-                    "test_simple_terminal_verbose.py::T::test_foo FAILED *100%*",
+                    "test_simple_terminal_verbose.py::T::test_foo SUBFAIL *100%*",
+                    "test_simple_terminal_verbose.py::T::test_foo SUBFAIL *100%*",
                     "test_simple_terminal_verbose.py::T::test_foo PASSED *100%*",
                 ]
             else:
@@ -177,8 +177,8 @@ class TestSubTest:
                 result = testdir.runpytest(simple_script, "-n1", "-v")
                 expected_lines = [
                     "gw0 [1]",
-                    "*gw0*100%* FAILED test_simple_terminal_verbose.py::T::test_foo*",
-                    "*gw0*100%* FAILED test_simple_terminal_verbose.py::T::test_foo*",
+                    "*gw0*100%* SUBFAIL test_simple_terminal_verbose.py::T::test_foo*",
+                    "*gw0*100%* SUBFAIL test_simple_terminal_verbose.py::T::test_foo*",
                     "*gw0*100%* PASSED test_simple_terminal_verbose.py::T::test_foo*",
                 ]
             result.stdout.fnmatch_lines(
@@ -274,8 +274,8 @@ class TestCapture:
             [
                 "start test",
                 "hello stdout A",
-                "Fhello stdout B",
-                "Fend test",
+                "uhello stdout B",
+                "uend test",
                 "*__ test (i='A') __*",
                 "*__ test (i='B') __*",
                 "*__ test __*",


### PR DESCRIPTION
Use "SUBPASS" and "," for passed subtests instead of general "PASSED",
"SUBFAIL" and "u" for failed ones instead of "FAILED".