### PR TITLE
fix: Allow subtests to xfail

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 CHANGELOG
 =========
 
+0.5.0 (2021-05-29)
+------------------
+
+* Add support for ``pytest.mark.xfail`` (`#40`_).
+
+.. _#40: https://github.com/pytest-dev/pytest-subtests/pull/40
+
 0.4.0 (2020-12-13)
 ------------------
 

--- a/pytest_subtests.py
+++ b/pytest_subtests.py
@@ -71,6 +71,10 @@ class SubTestReport(TestReport):
         )
         return report
 
+    @classmethod
+    def from_test_report(cls, test_report):
+        return super()._from_json(test_report._to_json())
+
 
 def _addSubTest(self, test_case, test, exc_info):
     if exc_info is not None:
@@ -78,7 +82,8 @@ def _addSubTest(self, test_case, test, exc_info):
         call_info = make_call_info(
             ExceptionInfo(exc_info), start=0, stop=0, duration=0, when="call"
         )
-        sub_report = SubTestReport.from_item_and_call(item=self, call=call_info)
+        report = self.ihook.pytest_runtest_makereport(item=self, call=call_info)
+        sub_report = SubTestReport.from_test_report(report)
         sub_report.context = SubTestContext(msg, dict(test.params))
         self.ihook.pytest_runtest_logreport(report=sub_report)
         if check_interactive_exception(call_info, sub_report):
@@ -171,7 +176,8 @@ class SubTests(object):
         call_info = make_call_info(
             exc_info, start=start, stop=stop, duration=duration, when="call"
         )
-        sub_report = SubTestReport.from_item_and_call(item=self.item, call=call_info)
+        report = self.ihook.pytest_runtest_makereport(item=self.item, call=call_info)
+        sub_report = SubTestReport.from_test_report(report)
         sub_report.context = SubTestContext(msg, kwargs.copy())
 
         captured.update_report(sub_report)

--- a/pytest_subtests.py
+++ b/pytest_subtests.py
@@ -72,7 +72,7 @@ class SubTestReport(TestReport):
         return report
 
     @classmethod
-    def from_test_report(cls, test_report):
+    def _from_test_report(cls, test_report):
         return super()._from_json(test_report._to_json())
 
 
@@ -83,7 +83,7 @@ def _addSubTest(self, test_case, test, exc_info):
             ExceptionInfo(exc_info), start=0, stop=0, duration=0, when="call"
         )
         report = self.ihook.pytest_runtest_makereport(item=self, call=call_info)
-        sub_report = SubTestReport.from_test_report(report)
+        sub_report = SubTestReport._from_test_report(report)
         sub_report.context = SubTestContext(msg, dict(test.params))
         self.ihook.pytest_runtest_logreport(report=sub_report)
         if check_interactive_exception(call_info, sub_report):
@@ -177,7 +177,7 @@ class SubTests(object):
             exc_info, start=start, stop=stop, duration=duration, when="call"
         )
         report = self.ihook.pytest_runtest_makereport(item=self.item, call=call_info)
-        sub_report = SubTestReport.from_test_report(report)
+        sub_report = SubTestReport._from_test_report(report)
         sub_report.context = SubTestContext(msg, kwargs.copy())
 
         captured.update_report(sub_report)


### PR DESCRIPTION
This change ensures that all `makereport` hooks get called prior to
subtests transforming the constructed `TestReport` to a `SubTestReport`.
A test is added for pytest style usage and an xfailing test is added for
unittest style since the same issue affecting skip counting is present
for xfail counting.

Fixes #24