### PR TITLE
Fix readme warnings suggestion

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,7 +53,7 @@ For now users can ignore those warnings by adding this to their configuration fi
 
     [pytest]
     filterwarnings =
-        ignore:A private pytest class or function was used.:PytestDeprecationWarning
+        ignore:A private pytest class or function was used.:pytest.PytestDeprecationWarning
 
 Installation
 ------------


### PR DESCRIPTION
I needed to include the module of the warning in the pytest config or else I got a `warnings._OptionError: unknown warning category: 'PytestDeprecationWarning'` error. With this change, the warning is properly ignored.