### PR TITLE
count passing subtests separately and show them in final summary

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 CHANGELOG
 =========
 
+0.8.0 (2022-05-26)
+------------------
+
+* Now passing subtests are shown in the test run summary at the end (for example: ``10 failed, 1 passed, 10 subtests passed in 0.10s``) (`#70`_).
+
+.. _#70: https://github.com/pytest-dev/pytest-subtests/pull/70
+
 0.7.0 (2022-02-13)
 ------------------
 

--- a/pytest_subtests.py
+++ b/pytest_subtests.py
@@ -35,10 +35,6 @@ class SubTestReport(TestReport):
     context = attr.ib()
 
     @property
-    def count_towards_summary(self):
-        return not self.passed
-
-    @property
     def head_line(self):
         _, _, domain = self.location
         return f"{domain} {self.sub_test_description()}"
@@ -249,7 +245,7 @@ def pytest_report_teststatus(report):
 
     outcome = report.outcome
     if report.passed:
-        return outcome, ",", "SUBPASS"
+        return f"subtests {outcome}", ",", "SUBPASS"
     elif report.skipped:
         return outcome, "-", "SUBSKIP"
     elif outcome == "failed":

--- a/tests/test_subtests.py
+++ b/tests/test_subtests.py
@@ -32,7 +32,7 @@ class TestFixture:
         expected_lines += [
             "* test_foo [[]custom[]] (i=1) *",
             "* test_foo [[]custom[]] (i=3) *",
-            "* 2 failed, 1 passed in *",
+            "* 2 failed, 1 passed, 3 subtests passed in *",
         ]
         result.stdout.fnmatch_lines(expected_lines)
 
@@ -64,7 +64,7 @@ class TestFixture:
         expected_lines += [
             "* test_foo [[]custom[]] (i=1) *",
             "* test_foo [[]custom[]] (i=3) *",
-            "* 2 failed, 1 passed in *",
+            "* 2 failed, 1 passed, 3 subtests passed in *",
         ]
         result.stdout.fnmatch_lines(expected_lines)
 
@@ -86,7 +86,7 @@ class TestFixture:
             pytest.importorskip("xdist")
             result = testdir.runpytest("-n1")
             expected_lines = ["gw0 [1]"]
-        expected_lines += ["* 1 passed, 3 skipped in *"]
+        expected_lines += ["* 1 passed, 3 skipped, 2 subtests passed in *"]
         result.stdout.fnmatch_lines(expected_lines)
 
     def test_xfail(self, testdir, mode):
@@ -107,7 +107,7 @@ class TestFixture:
             pytest.importorskip("xdist")
             result = testdir.runpytest("-n1")
             expected_lines = ["gw0 [1]"]
-        expected_lines += ["* 1 passed, 3 xfailed in *"]
+        expected_lines += ["* 1 passed, 3 xfailed, 2 subtests passed in *"]
         result.stdout.fnmatch_lines(expected_lines)
 
 


### PR DESCRIPTION
This does not alter the handling of skipped/failing tests, which aggregate alongside the normal test counts.

Previously we didn't count passing subtests in any totals to match unittest's behavior.

I don't love this solution as the inconsistency between the counting of passed vs skipped/failed is very odd to me, but if matching unittest is a requirement then this will serve 😄 

fixes #39 