### PR TITLE
Drop support for python 3.6

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,6 @@ jobs:
           "windows-py39",
           "windows-py310",
 
-          "ubuntu-py36",
           "ubuntu-py37",
           "ubuntu-py38",
           "ubuntu-py39",
@@ -44,10 +43,6 @@ jobs:
             os: windows-latest
             tox_env: "py310"
 
-          - name: "ubuntu-py36"
-            python: "3.6"
-            os: ubuntu-latest
-            tox_env: "py36"
           - name: "ubuntu-py37"
             python: "3.7"
             os: ubuntu-latest

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+Unreleased
+----------
+
+* Dropped support for Python 3.6.
+
 0.8.0 (2022-05-26)
 ------------------
 

--- a/pytest_subtests.py
+++ b/pytest_subtests.py
@@ -1,6 +1,6 @@
-import sys
 import time
 from contextlib import contextmanager
+from contextlib import nullcontext
 
 import attr
 import pytest
@@ -13,15 +13,6 @@ from _pytest.reports import TestReport
 from _pytest.runner import CallInfo
 from _pytest.runner import check_interactive_exception
 from _pytest.unittest import TestCaseFunction
-
-if sys.version_info[:2] < (3, 7):
-
-    @contextmanager
-    def nullcontext():
-        yield
-
-else:
-    from contextlib import nullcontext
 
 
 @attr.s

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     py_modules=["pytest_subtests"],
     use_scm_version=True,
     setup_requires=["setuptools-scm", "setuptools>=40.0"],
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     install_requires=["pytest>=7.0"],
     classifiers=[
         "Development Status :: 4 - Beta",
@@ -29,7 +29,6 @@ setup(
         "Topic :: Software Development :: Testing",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,py38,py39,py310
+envlist = py37,py38,py39,py310
 
 [testenv]
 passenv = USER USERNAME TRAVIS PYTEST_ADDOPTS


### PR DESCRIPTION
py3.6 is now deprecated, and not supported in pytest either