### PR TITLE
py3.11 compatibility for tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,9 +71,9 @@ jobs:
             tox_env: "py311"
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Set up Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python }}
     - name: Install tox

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,11 +18,13 @@ jobs:
           "windows-py38",
           "windows-py39",
           "windows-py310",
+          "windows-py311",
 
           "ubuntu-py37",
           "ubuntu-py38",
           "ubuntu-py39",
           "ubuntu-py310",
+          "ubuntu-py311",
         ]
 
         include:
@@ -42,6 +44,10 @@ jobs:
             python: "3.10"
             os: windows-latest
             tox_env: "py310"
+          - name: "windows-py311"
+            python: "3.11-dev"
+            os: windows-latest
+            tox_env: "py311"
 
           - name: "ubuntu-py37"
             python: "3.7"
@@ -59,6 +65,10 @@ jobs:
             python: "3.10"
             os: ubuntu-latest
             tox_env: "py310"
+          - name: "ubuntu-py311"
+            python: "3.11-dev"
+            os: ubuntu-latest
+            tox_env: "py311"
 
     steps:
     - uses: actions/checkout@v1

--- a/tests/test_subtests.py
+++ b/tests/test_subtests.py
@@ -2,6 +2,8 @@ import sys
 
 import pytest
 
+IS_PY311 = sys.version_info[:2] >= (3, 11)
+
 
 @pytest.mark.parametrize("mode", ["normal", "xdist"])
 class TestFixture:
@@ -137,13 +139,14 @@ class TestSubTest:
     @pytest.mark.parametrize("runner", ["unittest", "pytest-normal", "pytest-xdist"])
     def test_simple_terminal_normal(self, simple_script, testdir, runner):
 
+        suffix = ".test_foo" if IS_PY311 else ""
         if runner == "unittest":
             result = testdir.run(sys.executable, simple_script)
             result.stderr.fnmatch_lines(
                 [
-                    "FAIL: test_foo (__main__.T) [custom] (i=1)",
+                    f"FAIL: test_foo (__main__.T{suffix}) [custom] (i=1)",
                     "AssertionError: 1 != 0",
-                    "FAIL: test_foo (__main__.T) [custom] (i=3)",
+                    f"FAIL: test_foo (__main__.T{suffix}) [custom] (i=3)",
                     "AssertionError: 1 != 0",
                     "Ran 1 test in *",
                     "FAILED (failures=2)",
@@ -171,14 +174,15 @@ class TestSubTest:
     @pytest.mark.parametrize("runner", ["unittest", "pytest-normal", "pytest-xdist"])
     def test_simple_terminal_verbose(self, simple_script, testdir, runner):
 
+        suffix = ".test_foo" if IS_PY311 else ""
         if runner == "unittest":
             result = testdir.run(sys.executable, simple_script, "-v")
             result.stderr.fnmatch_lines(
                 [
-                    "test_foo (__main__.T) ... ",
-                    "FAIL: test_foo (__main__.T) [custom] (i=1)",
+                    f"test_foo (__main__.T{suffix}) ... ",
+                    f"FAIL: test_foo (__main__.T{suffix}) [custom] (i=1)",
                     "AssertionError: 1 != 0",
-                    "FAIL: test_foo (__main__.T) [custom] (i=3)",
+                    f"FAIL: test_foo (__main__.T{suffix}) [custom] (i=3)",
                     "AssertionError: 1 != 0",
                     "Ran 1 test in *",
                     "FAILED (failures=2)",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37,py38,py39,py310
+envlist = py37,py38,py39,py310,py311
 
 [testenv]
 passenv = USER USERNAME TRAVIS PYTEST_ADDOPTS


### PR DESCRIPTION
Closes https://github.com/pytest-dev/pytest-subtests/issues/69

In py3.11, the full test name now shows up. See https://github.com/python/cpython/pull/32138

Not sure if there's a better way to do this, I was hoping to do `(__main__.T*)` but that doesn't seem to play well with `fnmatch_lines`