### PR TITLE
Fix tox 4 error

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 envlist = py37,py38,py39,py310,py311
 
 [testenv]
-passenv = USER USERNAME TRAVIS PYTEST_ADDOPTS
+passenv = USER,USERNAME,TRAVIS,PYTEST_ADDOPTS
 deps =
     pytest-xdist>=1.28
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,11 @@
 envlist = py37,py38,py39,py310,py311
 
 [testenv]
-passenv = USER,USERNAME,TRAVIS,PYTEST_ADDOPTS
+passenv =
+    USER
+    USERNAME
+    TRAVIS
+    PYTEST_ADDOPTS
 deps =
     pytest-xdist>=1.28
 


### PR DESCRIPTION
```
py37: failed with pass_env values cannot contain whitespace, use comma to have multiple values in a single line, invalid values found 'USER USERNAME TRAVIS PYTEST_ADDOPTS'
```