### PR TITLE
add an option to disable shortletter output

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,7 @@
 CHANGELOG
 =========
 
-0.10.0 (2023-02-15)
+0.10.0 (UNRELEASED)
 -------------------
 
 * Added experimental support for suppressing subtest output dots in non-verbose mode with ``--no-subtests-shortletter``.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+0.10.0 (2023-02-15)
+------------------
+
+* Added experimental support for suppressing subtest output dots in non-verbose mode with ``--no-subtests-shortletter``.
+
 0.9.0 (2022-10-28)
 ------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,7 +2,7 @@ CHANGELOG
 =========
 
 0.10.0 (2023-02-15)
-------------------
+-------------------
 
 * Added experimental support for suppressing subtest output dots in non-verbose mode with ``--no-subtests-shortletter``.
 

--- a/pytest_subtests.py
+++ b/pytest_subtests.py
@@ -18,11 +18,11 @@ from _pytest.unittest import TestCaseFunction
 def pytest_addoption(parser):
     group = parser.getgroup("subtests")
     group.addoption(
-        "--disable-shortletter-output",
+        "--no-subtests-shortletter",
         action="store_true",
-        dest="disable_shortletter",
+        dest="no_subtests_shortletter",
         default=False,
-        help="Disables subtest output in non-verbose mode",
+        help="Disables subtest output 'dots' in non-verbose mode (EXPERIMENTAL)",
     )
 
 
@@ -247,11 +247,11 @@ def pytest_report_teststatus(report, config):
 
     outcome = report.outcome
     if report.passed:
-        short = "" if config.option.disable_shortletter else ","
+        short = "" if config.option.no_subtests_shortletter else ","
         return f"subtests {outcome}", short, "SUBPASS"
     elif report.skipped:
-        short = "" if config.option.disable_shortletter else "-"
+        short = "" if config.option.no_subtests_shortletter else "-"
         return outcome, short, "SUBSKIP"
     elif outcome == "failed":
-        short = "" if config.option.disable_shortletter else "u"
+        short = "" if config.option.no_subtests_shortletter else "u"
         return outcome, short, "SUBFAIL"


### PR DESCRIPTION
This allows the native pytest column calculations to not be disrupted and minimizes unneeded output for large CI systems.

This recomputes the correct output for every test. I'm not sure if that's a significant performance impact (probably not), but if there's a better way to memoize it let me know and I'll be happy to change it.