### PR TITLE
Update `pypa/gh-action-pypi-publish` to `release/v1`

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,6 @@ jobs:
         path: dist
 
     - name: Publish package to PyPI
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        user: __token__
         password: ${{ secrets.pypi_token }}


### PR DESCRIPTION
The `master` branch has been deprecated for quite a while and is way out-of-date. `release/v1` corresponds to the stable API.

Also, `__token__` has always been the default username so it's not needed either.