### PR TITLE
Passing subtests no longer turn the output yellow (similar to warnings)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,9 +4,13 @@ CHANGELOG
 UNRELEASED
 ----------
 
+* Passing subtests no longer turn the pytest output to yellow (as if warnings have been issued) (`#86`_). Thanks to `Andrew-Brock`_ for providing the solution.
 * Now the ``msg`` contents of a subtest is displayed when running pytest with ``-v`` (`#6`_).
 
 .. _#6: https://github.com/pytest-dev/pytest-subtests/issues/6
+.. _#86: https://github.com/pytest-dev/pytest-subtests/issues/86
+
+.. _`Andrew-Brock`: https://github.com/Andrew-Brock
 
 0.10.0 (2022-02-15)
 -------------------

--- a/tests/test_subtests.py
+++ b/tests/test_subtests.py
@@ -29,7 +29,7 @@ class TestFixture:
         else:
             pytest.importorskip("xdist")
             result = testdir.runpytest("-n1")
-            expected_lines = ["gw0 [1]"]
+            expected_lines = ["1 worker [1 item]"]
 
         expected_lines += [
             "* test_foo [[]custom[]] (i=1) *",
@@ -54,7 +54,7 @@ class TestFixture:
             pytest.importorskip("xdist")
             result = testdir.runpytest("-n1", "-v")
             expected_lines = [
-                "gw0 [1]",
+                "1 worker [1 item]",
                 "*gw0*100%* test_simple_terminal_verbose.py::test_foo*",
                 "*gw0*100%* test_simple_terminal_verbose.py::test_foo*",
                 "*gw0*100%* test_simple_terminal_verbose.py::test_foo*",
@@ -87,7 +87,7 @@ class TestFixture:
         else:
             pytest.importorskip("xdist")
             result = testdir.runpytest("-n1")
-            expected_lines = ["gw0 [1]"]
+            expected_lines = ["1 worker [1 item]"]
         expected_lines += ["* 1 passed, 3 skipped, 2 subtests passed in *"]
         result.stdout.fnmatch_lines(expected_lines)
 
@@ -108,7 +108,7 @@ class TestFixture:
         else:
             pytest.importorskip("xdist")
             result = testdir.runpytest("-n1")
-            expected_lines = ["gw0 [1]"]
+            expected_lines = ["1 worker [1 item]"]
         expected_lines += ["* 1 passed, 3 xfailed, 2 subtests passed in *"]
         result.stdout.fnmatch_lines(expected_lines)
 
@@ -159,7 +159,7 @@ class TestSubTest:
             else:
                 pytest.importorskip("xdist")
                 result = testdir.runpytest(simple_script, "-n1")
-                expected_lines = ["gw0 [1]"]
+                expected_lines = ["1 worker [1 item]"]
             result.stdout.fnmatch_lines(
                 expected_lines
                 + [
@@ -201,7 +201,7 @@ class TestSubTest:
                 pytest.importorskip("xdist")
                 result = testdir.runpytest(simple_script, "-n1", "-v")
                 expected_lines = [
-                    "gw0 [1]",
+                    "1 worker [1 item]",
                     "*gw0*100%* SUBFAIL test_simple_terminal_verbose.py::T::test_foo*",
                     "*gw0*100%* SUBFAIL test_simple_terminal_verbose.py::T::test_foo*",
                     "*gw0*100%* PASSED test_simple_terminal_verbose.py::T::test_foo*",

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ passenv =
     TRAVIS
     PYTEST_ADDOPTS
 deps =
-    pytest-xdist>=1.28
+    pytest-xdist>=3.3.0
 
 commands =
     pytest {posargs:tests}


### PR DESCRIPTION
Fix #86

cc @Andrew-Brock