### PR TITLE
Update README.rst - remove license links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -167,9 +167,6 @@ If you encounter any problems, please `file an issue`_ along with a detailed des
 .. _`Cookiecutter`: https://github.com/audreyr/cookiecutter
 .. _`@hackebrot`: https://github.com/hackebrot
 .. _`MIT`: http://opensource.org/licenses/MIT
-.. _`BSD-3`: http://opensource.org/licenses/BSD-3-Clause
-.. _`GNU GPL v3.0`: http://www.gnu.org/licenses/gpl-3.0.txt
-.. _`Apache Software License 2.0`: http://www.apache.org/licenses/LICENSE-2.0
 .. _`cookiecutter-pytest-plugin`: https://github.com/pytest-dev/cookiecutter-pytest-plugin
 .. _`file an issue`: https://github.com/pytest-dev/pytest-subtests/issues
 .. _`pytest`: https://github.com/pytest-dev/pytest


### PR DESCRIPTION
Remove reference links to Apache, BSD and GNU licenses because they are not actually used anywhere.

These caused a false positive  license ID when scanning another repo with FOSSA (https://app.fossa.com/projects)