### PR TITLE
Fixed link to PyPI in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -172,4 +172,4 @@ If you encounter any problems, please `file an issue`_ along with a detailed des
 .. _`pytest`: https://github.com/pytest-dev/pytest
 .. _`tox`: https://tox.readthedocs.io/en/latest/
 .. _`pip`: https://pypi.org/project/pip/
-.. _`PyPI`: https://pypi.org/project
+.. _`PyPI`: https://pypi.org/project/pytest-subtests/


### PR DESCRIPTION
Hi,

I noticed that the PyPI link in the README was linking to a 404 page.
I opted to link to the project page itself, rather than the PyPI homepage since it seemed more useful.