### PR TITLE
Hide `SubTests.test()` from tracebacks

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 CHANGELOG
 =========
 
+UNRELEASED
+----------
+
+* Hide the traceback inside the ``SubTests.test()`` method (`#131`_).
+
+.. _#131: https://github.com/pytest-dev/pytest-subtests/pull/131
+
 0.12.1 (2024-03-07)
 -------------------
 

--- a/src/pytest_subtests/plugin.py
+++ b/src/pytest_subtests/plugin.py
@@ -224,6 +224,9 @@ class SubTests:
         msg: str | None = None,
         **kwargs: Any,
     ) -> Generator[None, None, None]:
+        # Hide from tracebacks.
+        __tracebackhide__ = True
+    
         start = time.time()
         precise_start = time.perf_counter()
         exc_info = None

--- a/src/pytest_subtests/plugin.py
+++ b/src/pytest_subtests/plugin.py
@@ -226,7 +226,7 @@ class SubTests:
     ) -> Generator[None, None, None]:
         # Hide from tracebacks.
         __tracebackhide__ = True
-    
+
         start = time.time()
         precise_start = time.perf_counter()
         exc_info = None


### PR DESCRIPTION
Does the same as described in https://docs.pytest.org/en/7.1.x/example/simple.html#writing-well-integrated-assertion-helpers.

Will certainly help with reading what failed in subtests ran from `runpy.run_path()`.

Here's an example for [lazy_importing](https://github.com/bswck/lazy_importing) with [quite unusual test setup](https://github.com/bswck/lazy_importing/blob/main/tests).

**Before**
<details>

```
(lazy-importing-py3.8) ~/dev/lazy_importing git:(main|✚3)❯❯❯ pytest . -svvvv
Test session starts (platform: linux, Python 3.8.19, pytest 8.1.1, pytest-sugar 1.0.0)
cachedir: .pytest_cache
rootdir: /home/bswck/dev/lazy_importing
configfile: pyproject.toml
plugins: sugar-1.0.0, doctestplus-1.2.1, subtests-0.12.1, anyio-4.3.0
collected 1 item                                                                                                             



―――――――――――――――――――――――――――――――――――――――――――――― test_main [after-import-audits] ―――――――――――――――――――――――――――――――――――――――――――――――

self = SubTests(ihook=<_pytest.config.compat.PathAwareHookProxy object at 0x7fb72fb3d670>, suspend_capture_ctx=<bound method ...state='started' _in_suspended=False> _capture_fixture=None>>, request=<SubRequest 'subtests' for <Function test_main>>)
msg = 'after-import-audits', kwargs = {}, start = 1713811116.0532968, precise_start = 52446.820073351
exc_info = <ExceptionInfo AssertionError() tblen=2>, captured_output = Captured(out='', err='')
captured_logs = <pytest_subtests.plugin.CapturedLogs object at 0x7fb7304bb220>, precise_stop = 52446.820333051
duration = 0.00025969999842345715

    @contextmanager
    def test(
        self,
        msg: str | None = None,
        **kwargs: Any,
    ) -> Generator[None, None, None]:
        start = time.time()
        precise_start = time.perf_counter()
        exc_info = None
    
        with self._capturing_output() as captured_output, self._capturing_logs() as captured_logs:
            try:
>               yield

../../.cache/pypoetry/virtualenvs/lazy-importing-AoQMmhY1-py3.8/lib/python3.8/site-packages/pytest_subtests/plugin.py:233: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

    ... (REDACTED)
            # https://docs.python.org/3/reference/import.html#loader__
            if sys.version_info < (3, 14):
                expected_names_set.add("__loader__")
>           assert names_set == expected_names_set
E           AssertionError

tests/tests.py:83: AssertionError
----------------------------------------------------- Captured log call ------------------------------------------------------


 tests/run_tests.py::test_main ⨯✓✓✓✓✓✓✓✓✓✓✓                                                                    100% ██████████
================================================== short test summary info ===================================================
[after-import-audits] SUBFAIL tests/run_tests.py::test_main - AssertionError

Results (0.83s):
      13 passed
       1 failed
         - tests/run_tests.py:11 test_main
(lazy-importing-py3.8) ~/dev/lazy_importing git:(main|✚3)❯❯❯ 
```

</details>

**After**

<details>

```
(lazy-importing-py3.8) ~/dev/lazy_importing git:(main|✚3)❯❯❯ pytest . -svvvv
Test session starts (platform: linux, Python 3.8.19, pytest 8.1.1, pytest-sugar 1.0.0)
cachedir: .pytest_cache
rootdir: /home/bswck/dev/lazy_importing
configfile: pyproject.toml
plugins: sugar-1.0.0, doctestplus-1.2.1, subtests-0.12.1, anyio-4.3.0
collected 1 item                                                                                                             



―――――――――――――――――――――――――――――――――――――――――――――― test_main [after-import-audits] ―――――――――――――――――――――――――――――――――――――――――――――――

    ... (REDACTED)
            # https://docs.python.org/3/reference/import.html#loader__
            if sys.version_info < (3, 14):
                expected_names_set.add("__loader__")
>           assert names_set == expected_names_set
E           AssertionError

tests/tests.py:83: AssertionError
----------------------------------------------------- Captured log call ------------------------------------------------------


 tests/run_tests.py::test_main ⨯✓✓✓✓✓✓✓✓✓✓✓                                                                    100% ██████████
================================================== short test summary info ===================================================
[after-import-audits] SUBFAIL tests/run_tests.py::test_main - AssertionError

Results (0.40s):
      13 passed
       1 failed
         - tests/run_tests.py:11 test_main
(lazy-importing-py3.8) ~/dev/lazy_importing git:(main|✚3)❯❯❯ 
```

</details>
