### PR TITLE
Support -x to fail fast

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,9 +4,11 @@ CHANGELOG
 UNRELEASED
 ----------
 
+* Support ``-x/--exitfirst`` (`#134`_).
 * Hide the traceback inside the ``SubTests.test()`` method (`#131`_).
 
 .. _#131: https://github.com/pytest-dev/pytest-subtests/pull/131
+.. _#134: https://github.com/pytest-dev/pytest-subtests/pull/134
 
 0.12.1 (2024-03-07)
 -------------------


### PR DESCRIPTION
Attempts to progress on https://github.com/pytest-dev/pytest-subtests/issues/23.  Submitting as a draft to see if I can get some advice.  

Summary: Support for `pytest -x` to stop after the first failing subtest.  The implementation here does stop after the first failing subtest, however it also:
 
1.  Marks the parent test as a failure 
b/c
2. The `session.Failed` exception raised from inside the `subtests.test` is treated as an uncaught exception from within the test.  This results in the stack trace printed pointing to `contextlib` which feels undesirable to me.

I think the behavior in (1) is debatable.  On one hand - a failing subtest does not by default fail the parent test.  On the other hand, by design the parent test will not complete.  In either case, (2) I think would be really confusing for users.