### PR TITLE
Fix potential off by one error

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 CHANGELOG
 =========
 
+UNRELEASED
+----------
+
+* Fixed bug were an extra test would execute when ``-x/--exitfirst`` was used (`#139`_).
+
+.. _#139: https://github.com/pytest-dev/pytest-subtests/pull/139
+
 0.13.0 (2024-07-07)
 -------------------
 

--- a/src/pytest_subtests/plugin.py
+++ b/src/pytest_subtests/plugin.py
@@ -242,9 +242,6 @@ class _SubTestContextManager:
         __tracebackhide__ = True
         try:
             if exc_val is not None:
-                if self.request.session.shouldfail:
-                    return False
-
                 exc_info = ExceptionInfo.from_exception(exc_val)
             else:
                 exc_info = None
@@ -275,6 +272,10 @@ class _SubTestContextManager:
                 node=self.request.node, call=call_info, report=sub_report
             )
 
+        if exc_val is not None:
+            if self.request.session.shouldfail:
+                # return False
+                pytest.exit(reason=f"subtest failed")
         return True
 
 

--- a/src/pytest_subtests/plugin.py
+++ b/src/pytest_subtests/plugin.py
@@ -274,8 +274,7 @@ class _SubTestContextManager:
 
         if exc_val is not None:
             if self.request.session.shouldfail:
-                # return False
-                pytest.exit(reason=f"subtest failed")
+                return False
         return True
 
 

--- a/tests/test_subtests.py
+++ b/tests/test_subtests.py
@@ -608,4 +608,6 @@ def test_exitfirst(pytester: pytest.Pytester) -> None:
         consecutive=True,
     )
     result.stdout.no_fnmatch_line("*sub2*")  # sub2 not executed.
-    result.stdout.no_fnmatch_line("*This would fail the parent*")  # parent test neither passed nor failed
+    result.stdout.no_fnmatch_line(
+        "*This would fail the parent*"
+    )  # parent test neither passed nor failed

--- a/tests/test_subtests.py
+++ b/tests/test_subtests.py
@@ -593,7 +593,7 @@ def test_exitfirst(pytester: pytest.Pytester) -> None:
                 assert False
 
             with subtests.test("sub2"):
-                pass
+                assert False
         """
     )
     result = pytester.runpytest("--exitfirst")

--- a/tests/test_subtests.py
+++ b/tests/test_subtests.py
@@ -593,21 +593,17 @@ def test_exitfirst(pytester: pytest.Pytester) -> None:
                 assert False
 
             with subtests.test("sub2"):
-                assert True
-
-            assert False, "This would fail the parent, but shouldn't be reached"
+                assert False
         """
     )
     result = pytester.runpytest("--exitfirst")
-    assert result.parseoutcomes()["failed"] == 1  # sub1 failed
+    assert result.parseoutcomes()["failed"] == 2  # sub1 failed
     result.stdout.fnmatch_lines(
         [
             "*[[]sub1[]] SUBFAIL test_exitfirst.py::test_foo - assert False*",
-            "* stopping after 1 failures*",
+            "FAILED test_exitfirst.py::test_foo - assert False",
+            "* stopping after 2 failures*",
         ],
         consecutive=True,
     )
     result.stdout.no_fnmatch_line("*sub2*")  # sub2 not executed.
-    result.stdout.no_fnmatch_line(
-        "*This would fail the parent*"
-    )  # parent test neither passed nor failed

--- a/tests/test_subtests.py
+++ b/tests/test_subtests.py
@@ -593,11 +593,13 @@ def test_exitfirst(pytester: pytest.Pytester) -> None:
                 assert False
 
             with subtests.test("sub2"):
-                assert False
+                assert True
+
+            assert False, "This would fail the parent, but shouldn't be reached"
         """
     )
     result = pytester.runpytest("--exitfirst")
-    assert result.parseoutcomes()["failed"] == 1
+    assert result.parseoutcomes()["failed"] == 1  # sub1 failed
     result.stdout.fnmatch_lines(
         [
             "*[[]sub1[]] SUBFAIL test_exitfirst.py::test_foo - assert False*",
@@ -606,3 +608,4 @@ def test_exitfirst(pytester: pytest.Pytester) -> None:
         consecutive=True,
     )
     result.stdout.no_fnmatch_line("*sub2*")  # sub2 not executed.
+    result.stdout.no_fnmatch_line("*This would fail the parent*")  # parent test neither passed nor failed

--- a/tests/test_subtests.py
+++ b/tests/test_subtests.py
@@ -597,7 +597,7 @@ def test_exitfirst(pytester: pytest.Pytester) -> None:
         """
     )
     result = pytester.runpytest("--exitfirst")
-    assert result.parseoutcomes()["failed"] == 2  # sub1 failed
+    assert result.parseoutcomes()["failed"] == 2
     result.stdout.fnmatch_lines(
         [
             "*[[]sub1[]] SUBFAIL test_exitfirst.py::test_foo - assert False*",


### PR DESCRIPTION
In https://github.com/pytest-dev/pytest-subtests/pull/134 support was added for `--exitfirst`.  I think we might have an off by one error, this PR just illustrating with this small change to the tests.

I think the issue is that `self.request.session.shouldfail` does not get set until we call `pytest_runtest_logreport` which is after the flag is checked.  The result is the tests get stopped after the *2nd* failing subtest instead of the first.