### PR TITLE
Fix `skipTest` inside `subTest`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,9 +4,12 @@ CHANGELOG
 UNRELEASED
 ----------
 
-* Fix `pytest` requirement to `>=7.3` (`#159`_).
+* Fix output when using ``TestCase.skipTest`` (`#169`_).
+
+* Fix ``pytest`` requirement to ``>=7.3`` (`#159`_).
 
 .. _#159: https://github.com/pytest-dev/pytest-subtests/issues/159
+.. _#169: https://github.com/pytest-dev/pytest-subtests/pull/169
 
 0.13.1 (2024-07-16)
 -------------------

--- a/src/pytest_subtests/plugin.py
+++ b/src/pytest_subtests/plugin.py
@@ -171,9 +171,9 @@ def pytest_configure(config: pytest.Config) -> None:
     TestCaseFunction.addSubTest = _addSubTest  # type: ignore[attr-defined]
     TestCaseFunction.failfast = False  # type: ignore[attr-defined]
     # This condition is to prevent `TestCaseFunction._originaladdSkip` being assigned again in a subprocess from a
-    # parent python process where `addSkip` is already `_addSkip`. Without this guard condition, `_originaladdSkip` is
-    # assigned to `_addSkip` and cause an infinite recursion. A such case is when running tests in `test_subtests.py`
-    # where `pytester.runpytest` is used.
+    # parent python process where `addSkip` is already `_addSkip`. A such case is when running tests in
+    # `test_subtests.py` where `pytester.runpytest` is used. Without this guard condition, `_originaladdSkip` is
+    # assigned to `_addSkip` which is wrong as well as causing an infinite recursion in some cases.
     if not hasattr(TestCaseFunction, "_originaladdSkip"):
         TestCaseFunction._originaladdSkip = TestCaseFunction.addSkip  # type: ignore[attr-defined]
     TestCaseFunction.addSkip = _addSkip  # type: ignore[method-assign]

--- a/src/pytest_subtests/plugin.py
+++ b/src/pytest_subtests/plugin.py
@@ -100,7 +100,7 @@ class SubTestReport(TestReport):  # type: ignore[misc]
         return super()._from_json(test_report._to_json())
 
 
-def _addSkip(self, testcase: TestCase, reason: str) -> None:
+def _addSkip(self: TestCaseFunction, testcase: TestCase, reason: str) -> None:
     if isinstance(testcase, _SubTest):
         self._originaladdSkip(testcase, reason)
         exc_info = self._excinfo[-1]

--- a/src/pytest_subtests/plugin.py
+++ b/src/pytest_subtests/plugin.py
@@ -152,10 +152,13 @@ def _addSubTest(
             for x, y in self.instance._outcome.errors
             if isinstance(x, _SubTest) and y is not None
         ]
-        # breakpoint()
-        if len(subtest_errors) > 0 and len(non_subtest_skip) > 0:
+        # Check if we have non-subtest skips: if there are also sub failures, non-subtest skips are not treated in
+        # `_addSubTest` and have to be added using `_originaladdSkip` after all subtest failures are processed.
+        if len(non_subtest_skip) > 0 and len(subtest_errors) > 0:
+            # Make sure we have processed the last subtest failure
             last_subset_error = subtest_errors[-1]
             if exc_info is last_subset_error[-1]:
+                # Add non-subtest skips (as they could not be treated in `_addSkip`)
                 for testcase, reason in non_subtest_skip:
                     self._originaladdSkip(testcase, reason)  # type: ignore[attr-defined]
 

--- a/src/pytest_subtests/plugin.py
+++ b/src/pytest_subtests/plugin.py
@@ -111,7 +111,7 @@ def _addSkip(self: TestCaseFunction, testcase: TestCase, reason: str) -> None:
         # `_addSubTest`.
         if (
             len(
-                [x for x, y in self.instance._outcome.errors if isinstance(x, _SubTest)]
+                [x for x, y in self.instance._outcome.errors if isinstance(x, _SubTest) and y is not None]
             )
             == 0
         ):
@@ -149,7 +149,7 @@ def _addSubTest(
             if not isinstance(x, _SubTest)
         ]
         subtest_errors = [
-            (x, y) for x, y in self.instance._outcome.errors if isinstance(x, _SubTest)
+            (x, y) for x, y in self.instance._outcome.errors if isinstance(x, _SubTest) and y is not None
         ]
         if len(subtest_errors) > 0 and len(non_subtest_skip) > 0:
             last_subset_error = subtest_errors[-1]

--- a/src/pytest_subtests/plugin.py
+++ b/src/pytest_subtests/plugin.py
@@ -103,8 +103,9 @@ class SubTestReport(TestReport):  # type: ignore[misc]
 def _addSkip(self: TestCaseFunction, testcase: TestCase, reason: str) -> None:
     if isinstance(testcase, _SubTest):
         self._originaladdSkip(testcase, reason)  # type: ignore[attr-defined]
-        exc_info = self._excinfo[-1]
-        self.addSubTest(testcase.test_case, testcase, exc_info)  # type: ignore[attr-defined]
+        if self._excinfo is not None:
+            exc_info = self._excinfo[-1]
+            self.addSubTest(testcase.test_case, testcase, exc_info)  # type: ignore[attr-defined]
     else:
         # The non-subtest skips have to be added by `_originaladdSkip` only after all subtest failures are processed by
         # `_addSubTest`.

--- a/src/pytest_subtests/plugin.py
+++ b/src/pytest_subtests/plugin.py
@@ -108,7 +108,11 @@ def _addSkip(self: TestCaseFunction, testcase: TestCase, reason: str) -> None:
     else:
         # The non-subtest skips have to be added by `_originaladdSkip` only after all subtest failures are processed by
         # `_addSubTest`.
-        subtest_errors = [x for x, y in self.instance._outcome.errors if isinstance(x, _SubTest) and y is not None]
+        subtest_errors = [
+            x
+            for x, y in self.instance._outcome.errors
+            if isinstance(x, _SubTest) and y is not None
+        ]
         if len(subtest_errors) == 0:
             self._originaladdSkip(testcase, reason)  # type: ignore[attr-defined]
 
@@ -138,8 +142,16 @@ def _addSubTest(
             )
 
         # Add non-subtest skips once all subtest failures are processed by # `_addSubTest`.
-        non_subtest_skip = [(x, y) for x, y in self.instance._outcome.skipped if not isinstance(x, _SubTest)]
-        subtest_errors = [(x, y) for x, y in self.instance._outcome.errors if isinstance(x, _SubTest) and y is not None]
+        non_subtest_skip = [
+            (x, y)
+            for x, y in self.instance._outcome.skipped
+            if not isinstance(x, _SubTest)
+        ]
+        subtest_errors = [
+            (x, y)
+            for x, y in self.instance._outcome.errors
+            if isinstance(x, _SubTest) and y is not None
+        ]
         # breakpoint()
         if len(subtest_errors) > 0 and len(non_subtest_skip) > 0:
             last_subset_error = subtest_errors[-1]

--- a/src/pytest_subtests/plugin.py
+++ b/src/pytest_subtests/plugin.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import copy
 import sys
 import time
 from contextlib import contextmanager
@@ -157,6 +156,7 @@ def _addSubTest(
             for x, y in self.instance._outcome.errors
             if isinstance(x, _SubTest) and y is not None
         ]
+        # breakpoint()
         if len(subtest_errors) > 0 and len(non_subtest_skip) > 0:
             last_subset_error = subtest_errors[-1]
             if exc_info is last_subset_error[-1]:
@@ -167,7 +167,7 @@ def _addSubTest(
 def pytest_configure(config: pytest.Config) -> None:
     TestCaseFunction.addSubTest = _addSubTest  # type: ignore[attr-defined]
     TestCaseFunction.failfast = False  # type: ignore[attr-defined]
-    TestCaseFunction._originaladdSkip = copy.copy(TestCaseFunction.addSkip)  # type: ignore[attr-defined]
+    TestCaseFunction._originaladdSkip = TestCaseFunction.addSkip  # type: ignore[attr-defined]
     TestCaseFunction.addSkip = _addSkip  # type: ignore[method-assign]
 
     # Hack (#86): the terminal does not know about the "subtests"
@@ -198,7 +198,7 @@ def pytest_unconfigure() -> None:
     if hasattr(TestCaseFunction, "failfast"):
         del TestCaseFunction.failfast
     if hasattr(TestCaseFunction, "_originaladdSkip"):
-        TestCaseFunction.addSkip = copy.copy(TestCaseFunction._originaladdSkip)  # type: ignore[method-assign]
+        TestCaseFunction.addSkip = TestCaseFunction._originaladdSkip  # type: ignore[method-assign]
         del TestCaseFunction._originaladdSkip
 
 

--- a/src/pytest_subtests/plugin.py
+++ b/src/pytest_subtests/plugin.py
@@ -102,9 +102,9 @@ class SubTestReport(TestReport):  # type: ignore[misc]
 
 def _addSkip(self: TestCaseFunction, testcase: TestCase, reason: str) -> None:
     if isinstance(testcase, _SubTest):
-        self._originaladdSkip(testcase, reason)
+        self._originaladdSkip(testcase, reason)  # type: ignore[attr-defined]
         exc_info = self._excinfo[-1]
-        self.addSubTest(testcase.test_case, testcase, exc_info)
+        self.addSubTest(testcase.test_case, testcase, exc_info)  # type: ignore[attr-defined]
     else:
         # The non-subtest skips have to be added by `_originaladdSkip` only after all subtest failures are processed by
         # `_addSubTest`.
@@ -114,7 +114,7 @@ def _addSkip(self: TestCaseFunction, testcase: TestCase, reason: str) -> None:
             )
             == 0
         ):
-            self._originaladdSkip(testcase, reason)
+            self._originaladdSkip(testcase, reason)  # type: ignore[attr-defined]
 
 
 def _addSubTest(

--- a/src/pytest_subtests/plugin.py
+++ b/src/pytest_subtests/plugin.py
@@ -14,7 +14,7 @@ from typing import Iterator
 from typing import Mapping
 from typing import TYPE_CHECKING
 from unittest import TestCase
-from unittest.case import _SubTest
+from unittest.case import _SubTest  # type: ignore[attr-defined]
 
 import attr
 import pluggy

--- a/src/pytest_subtests/plugin.py
+++ b/src/pytest_subtests/plugin.py
@@ -100,7 +100,7 @@ class SubTestReport(TestReport):  # type: ignore[misc]
         return super()._from_json(test_report._to_json())
 
 
-def _addSkip(self, testcase: "unittest.TestCase", reason: str) -> None:
+def _addSkip(self, testcase: TestCase, reason: str) -> None:
     if isinstance(testcase, _SubTest):
         self._originaladdSkip(testcase, reason)
         exc_info = self._excinfo[-1]
@@ -154,7 +154,7 @@ def _addSubTest(
             last_subset_error = subtest_errors[-1]
             if exc_info is last_subset_error[-1]:
                 for testcase, reason in non_subtest_skip:
-                    self._originaladdSkip(testcase, reason)
+                    self._originaladdSkip(testcase, reason)  # type: ignore[attr-defined]
 
 
 def pytest_configure(config: pytest.Config) -> None:

--- a/src/pytest_subtests/plugin.py
+++ b/src/pytest_subtests/plugin.py
@@ -111,7 +111,11 @@ def _addSkip(self: TestCaseFunction, testcase: TestCase, reason: str) -> None:
         # `_addSubTest`.
         if (
             len(
-                [x for x, y in self.instance._outcome.errors if isinstance(x, _SubTest) and y is not None]
+                [
+                    x
+                    for x, y in self.instance._outcome.errors
+                    if isinstance(x, _SubTest) and y is not None
+                ]
             )
             == 0
         ):
@@ -149,7 +153,9 @@ def _addSubTest(
             if not isinstance(x, _SubTest)
         ]
         subtest_errors = [
-            (x, y) for x, y in self.instance._outcome.errors if isinstance(x, _SubTest) and y is not None
+            (x, y)
+            for x, y in self.instance._outcome.errors
+            if isinstance(x, _SubTest) and y is not None
         ]
         if len(subtest_errors) > 0 and len(non_subtest_skip) > 0:
             last_subset_error = subtest_errors[-1]

--- a/src/pytest_subtests/plugin.py
+++ b/src/pytest_subtests/plugin.py
@@ -108,16 +108,8 @@ def _addSkip(self: TestCaseFunction, testcase: TestCase, reason: str) -> None:
     else:
         # The non-subtest skips have to be added by `_originaladdSkip` only after all subtest failures are processed by
         # `_addSubTest`.
-        if (
-            len(
-                [
-                    x
-                    for x, y in self.instance._outcome.errors
-                    if isinstance(x, _SubTest) and y is not None
-                ]
-            )
-            == 0
-        ):
+        subtest_errors = [x for x, y in self.instance._outcome.errors if isinstance(x, _SubTest) and y is not None]
+        if len(subtest_errors) == 0:
             self._originaladdSkip(testcase, reason)  # type: ignore[attr-defined]
 
 
@@ -146,16 +138,8 @@ def _addSubTest(
             )
 
         # Add non-subtest skips once all subtest failures are processed by # `_addSubTest`.
-        non_subtest_skip = [
-            (x, y)
-            for x, y in self.instance._outcome.skipped
-            if not isinstance(x, _SubTest)
-        ]
-        subtest_errors = [
-            (x, y)
-            for x, y in self.instance._outcome.errors
-            if isinstance(x, _SubTest) and y is not None
-        ]
+        non_subtest_skip = [(x, y) for x, y in self.instance._outcome.skipped if not isinstance(x, _SubTest)]
+        subtest_errors = [(x, y) for x, y in self.instance._outcome.errors if isinstance(x, _SubTest) and y is not None]
         # breakpoint()
         if len(subtest_errors) > 0 and len(non_subtest_skip) > 0:
             last_subset_error = subtest_errors[-1]

--- a/src/pytest_subtests/plugin.py
+++ b/src/pytest_subtests/plugin.py
@@ -150,7 +150,7 @@ def pytest_configure(config: pytest.Config) -> None:
     TestCaseFunction.addSubTest = _addSubTest  # type: ignore[attr-defined]
     TestCaseFunction.failfast = False  # type: ignore[attr-defined]
     TestCaseFunction._originaladdSkip = copy.copy(TestCaseFunction.addSkip)  # type: ignore[attr-defined]
-    TestCaseFunction.addSkip = _addSkip  # type: ignore[attr-defined]
+    TestCaseFunction.addSkip = _addSkip  # type: ignore[method-assign]
 
     # Hack (#86): the terminal does not know about the "subtests"
     # status, so it will by default turn the output to yellow.
@@ -180,7 +180,7 @@ def pytest_unconfigure() -> None:
     if hasattr(TestCaseFunction, "failfast"):
         del TestCaseFunction.failfast
     if hasattr(TestCaseFunction, "_originaladdSkip"):
-        TestCaseFunction.addSkip = copy.copy(TestCaseFunction._originaladdSkip)
+        TestCaseFunction.addSkip = copy.copy(TestCaseFunction._originaladdSkip)  # type: ignore[method-assign]
         del TestCaseFunction._originaladdSkip
 
 

--- a/src/pytest_subtests/plugin.py
+++ b/src/pytest_subtests/plugin.py
@@ -13,7 +13,6 @@ from typing import Iterator
 from typing import Mapping
 from typing import TYPE_CHECKING
 from unittest import TestCase
-from unittest.case import _SubTest  # type: ignore[attr-defined]
 
 import attr
 import pluggy
@@ -100,6 +99,8 @@ class SubTestReport(TestReport):  # type: ignore[misc]
 
 
 def _addSkip(self: TestCaseFunction, testcase: TestCase, reason: str) -> None:
+    from unittest.case import _SubTest  # type: ignore[attr-defined]
+
     if isinstance(testcase, _SubTest):
         self._originaladdSkip(testcase, reason)  # type: ignore[attr-defined]
         if self._excinfo is not None:
@@ -146,6 +147,8 @@ def _addSubTest(
 
         # For python < 3.11: add non-subtest skips once all subtest failures are processed by # `_addSubTest`.
         if sys.version_info < (3, 11):
+            from unittest.case import _SubTest  # type: ignore[attr-defined]
+
             non_subtest_skip = [
                 (x, y)
                 for x, y in self.instance._outcome.skipped

--- a/tests/test_subtests.py
+++ b/tests/test_subtests.py
@@ -420,7 +420,7 @@ class TestSubTest:
             class T(TestCase):
                 def test_foo(self):
                     for i in range(10):
-                        with self.subTest("custom message", i=i):    
+                        with self.subTest("custom message", i=i):
                             if i < 4:
                                 self.skipTest(f"skip subtest i={i}")
                             assert i < 4

--- a/tests/test_subtests.py
+++ b/tests/test_subtests.py
@@ -341,6 +341,64 @@ class TestSubTest:
             )
 
 
+    @pytest.mark.parametrize("runner", ["unittest", "pytest-normal", "pytest-xdist"])
+    def test_skip_with_failure(
+        self,
+        pytester: pytest.Pytester,
+        runner: Literal["unittest", "pytest-normal", "pytest-xdist"],
+    ) -> None:
+        p = pytester.makepyfile(
+            """
+            import pytest
+            from unittest import expectedFailure, TestCase, main
+
+            class T(TestCase):
+                def test_foo(self):
+                    for i in range(10):
+                        with self.subTest("custom message", i=i):    
+                            if i < 4:
+                                self.skipTest(f"skip subtest i={i}")
+                            assert i < 4
+
+            if __name__ == '__main__':
+                main()
+        """
+        )
+        if runner == "unittest":
+            result = pytester.runpython(p)
+            breakpoint()
+            result.stderr.re_match_lines(
+                [
+                    "FAIL: test_foo \(__main__\.T\) \[custom message\] \(i=4\).*",
+                    "FAIL: test_foo \(__main__\.T\) \[custom message\] \(i=9\).*",
+                    "Ran 1 test in .*",
+                    "FAILED \(failures=6, skipped=4\)",
+                ]
+            )
+        elif runner == "pytest-normal":
+            result = pytester.runpytest(p, "-v", "-rsf")
+            result.stdout.re_match_lines(
+                [
+                    r"test_skip_with_failure.py::T::test_foo \[custom message\] \(i=0\) SUBSKIP \(skip subtest i=0\) .*",
+                    r"test_skip_with_failure.py::T::test_foo \[custom message\] \(i=3\) SUBSKIP \(skip subtest i=3\) .*",
+                    r"test_skip_with_failure.py::T::test_foo \[custom message\] \(i=4\) SUBFAIL .*",
+                    r"test_skip_with_failure.py::T::test_foo \[custom message\] \(i=9\) SUBFAIL .*",
+                    "test_skip_with_failure.py::T::test_foo PASSED .*",
+                    "[custom message] (i=0) SUBSKIP [1] test_skip_with_failure.py:5: skip subtest i=0",
+                    "[custom message] (i=0) SUBSKIP [1] test_skip_with_failure.py:5: skip subtest i=3",
+                    "[custom message] (i=4) SUBFAIL test_skip_with_failure.py::T::test_foo - AssertionError: assert 4 < 4",
+                    "[custom message] (i=9) SUBFAIL test_skip_with_failure.py::T::test_foo - AssertionError: assert 9 < 4",
+                    ".* 6 failed, 1 passed, 4 skipped in .*",
+                ]
+            )
+        else:
+            pytest.xfail("Not producing the expected results (#5)")
+            result = pytester.runpytest(p)  # type:ignore[unreachable]
+            result.stdout.fnmatch_lines(
+                ["collected 1 item", "* 3 skipped, 1 passed in *"]
+            )
+
+
 class TestCapture:
     def create_file(self, pytester: pytest.Pytester) -> None:
         pytester.makepyfile(

--- a/tests/test_subtests.py
+++ b/tests/test_subtests.py
@@ -344,8 +344,10 @@ class TestSubTest:
     def test_skip_with_failure(
         self,
         pytester: pytest.Pytester,
+        monkeypatch: pytest.MonkeyPatch,
         runner: Literal["unittest", "pytest-normal", "pytest-xdist"],
     ) -> None:
+        monkeypatch.setenv("COLUMNS", "200")
         p = pytester.makepyfile(
             """
             import pytest
@@ -413,7 +415,7 @@ class TestSubTest:
         monkeypatch: pytest.MonkeyPatch,
         runner: Literal["unittest", "pytest-normal", "pytest-xdist"],
     ) -> None:
-        monkeypatch.setenv("COLUMNS", "80")
+        monkeypatch.setenv("COLUMNS", "200")
         p = pytester.makepyfile(
             """
             import pytest
@@ -458,7 +460,7 @@ class TestSubTest:
             result.stdout.re_match_lines(
                 [
                     r"test_skip_with_failure_and_non_subskip.py::T::test_foo \[custom message\] \(i=4\) SUBFAIL .*",
-                    r"test_skip_with_failure_and_non_subskip.py::T::test_foo SKIPPED \(skip...\)",
+                    r"test_skip_with_failure_and_non_subskip.py::T::test_foo SKIPPED \(skip the test\)",
                     r"\[custom message\] \(i=0\) SUBSKIP \[1\] test_skip_with_failure_and_non_subskip.py:5: skip subtest i=3",
                     r"\[custom message\] \(i=0\) SUBSKIP \[1\] test_skip_with_failure_and_non_subskip.py:5: skip the test",
                     r"\[custom message\] \(i=4\) SUBFAIL test_skip_with_failure_and_non_subskip.py::T::test_foo",
@@ -471,7 +473,7 @@ class TestSubTest:
                 result.stdout.re_match_lines(
                     [
                         r"test_skip_with_failure_and_non_subskip.py::T::test_foo \[custom message\] \(i=4\) SUBFAIL .*",
-                        r"test_skip_with_failure_and_non_subskip.py::T::test_foo SKIPPED \(skip...\).*",
+                        r"test_skip_with_failure_and_non_subskip.py::T::test_foo SKIPPED \(skip the test\).*",
                         r"\[custom message\] \(i=3\) SUBSKIP test_skip_with_failure_and_non_subskip.py::T::test_foo - Skipped: skip subtest i=3",
                         r"SKIPPED test_skip_with_failure_and_non_subskip.py::T::test_foo - Skipped: skip the test",
                         r"\[custom message\] \(i=4\) SUBFAIL test_skip_with_failure_and_non_subskip.py::T::test_foo",

--- a/tests/test_subtests.py
+++ b/tests/test_subtests.py
@@ -366,7 +366,6 @@ class TestSubTest:
         )
         if runner == "unittest":
             result = pytester.runpython(p)
-            breakpoint()
             result.stderr.re_match_lines(
                 [
                     "FAIL: test_foo \(__main__\.T\) \[custom message\] \(i=4\).*",

--- a/tests/test_subtests.py
+++ b/tests/test_subtests.py
@@ -410,7 +410,7 @@ class TestSubTest:
     def test_skip_with_failure_and_non_subskip(
         self,
         pytester: pytest.Pytester,
-            monkeypatch: pytest.MonkeyPatch,
+        monkeypatch: pytest.MonkeyPatch,
         runner: Literal["unittest", "pytest-normal", "pytest-xdist"],
     ) -> None:
         monkeypatch.setenv("COLUMNS", "80")

--- a/tests/test_subtests.py
+++ b/tests/test_subtests.py
@@ -410,8 +410,10 @@ class TestSubTest:
     def test_skip_with_failure_and_non_subskip(
         self,
         pytester: pytest.Pytester,
+            monkeypatch: pytest.MonkeyPatch,
         runner: Literal["unittest", "pytest-normal", "pytest-xdist"],
     ) -> None:
+        monkeypatch.setenv("COLUMNS", "80")
         p = pytester.makepyfile(
             """
             import pytest
@@ -456,10 +458,10 @@ class TestSubTest:
             result.stdout.re_match_lines(
                 [
                     r"test_skip_with_failure_and_non_subskip.py::T::test_foo \[custom message\] \(i=4\) SUBFAIL .*",
-                    r"test_skip_with_failure_and_non_subskip.py::T::test_foo SKIPPED \(skip the test\)",
+                    r"test_skip_with_failure_and_non_subskip.py::T::test_foo SKIPPED \(skip...\)",
                     r"\[custom message\] \(i=0\) SUBSKIP \[1\] test_skip_with_failure_and_non_subskip.py:5: skip subtest i=3",
                     r"\[custom message\] \(i=0\) SUBSKIP \[1\] test_skip_with_failure_and_non_subskip.py:5: skip the test",
-                    r"\[custom message\] \(i=4\) SUBFAIL test_skip_with_failure_and_non_subskip.py::T::test_foo - AssertionError: assert 4 < 4",
+                    r"\[custom message\] \(i=4\) SUBFAIL test_skip_with_failure_and_non_subskip.py::T::test_foo",
                     r".* 6 failed, 5 skipped in .*",
                 ]
             )
@@ -469,10 +471,10 @@ class TestSubTest:
                 result.stdout.re_match_lines(
                     [
                         r"test_skip_with_failure_and_non_subskip.py::T::test_foo \[custom message\] \(i=4\) SUBFAIL .*",
-                        r"test_skip_with_failure_and_non_subskip.py::T::test_foo SKIPPED \(skip the test\)",
+                        r"test_skip_with_failure_and_non_subskip.py::T::test_foo SKIPPED \(skip...\).*",
                         r"\[custom message\] \(i=3\) SUBSKIP test_skip_with_failure_and_non_subskip.py::T::test_foo - Skipped: skip subtest i=3",
                         r"SKIPPED test_skip_with_failure_and_non_subskip.py::T::test_foo - Skipped: skip the test",
-                        r"\[custom message\] \(i=4\) SUBFAIL test_skip_with_failure_and_non_subskip.py::T::test_foo - AssertionError: assert 4 < 4",
+                        r"\[custom message\] \(i=4\) SUBFAIL test_skip_with_failure_and_non_subskip.py::T::test_foo",
                         r".* 6 failed, 5 skipped in .*",
                     ]
                 )

--- a/tox.ini
+++ b/tox.ini
@@ -2,11 +2,6 @@
 envlist = py38,py39,py310,py311,py312
 
 [testenv]
-passenv =
-    USER
-    USERNAME
-    TRAVIS
-    PYTEST_ADDOPTS
 deps =
     pytest-xdist>=3.3.0
 


### PR DESCRIPTION
Currently, the reporting has issues in the cases where `skipTest` is used inside `subTest`. For example

```python
import unittest

class T(unittest.TestCase):
    def test_foo(self):
        for i in range(10):
            with self.subTest("custom message", i=i):
                if i < 4:
                    self.skipTest(f"skip {i}")
                assert i < 4
```
outputs
```bash
tests/test_foo.py::T::test_foo [custom message] (i=4) SUBSKIP (skip 0)
tests/test_foo.py::T::test_foo [custom message] (i=5) SUBSKIP (skip 1)
tests/test_foo.py::T::test_foo [custom message] (i=6) SUBSKIP (skip 2)
tests/test_foo.py::T::test_foo [custom message] (i=7) SUBSKIP (skip 3)
tests/test_foo.py::T::test_foo [custom message] (i=8) SUBFAIL
tests/test_foo.py::T::test_foo [custom message] (i=9) SUBFAIL
tests/test_foo.py::T::test_foo PASSED
...
=============== short test summary info ===============
[custom message] (i=8) SUBFAIL tests/test_foo.py::T::test_foo - AssertionError: assert 8 < 4
[custom message] (i=9) SUBFAIL tests/test_foo.py::T::test_foo - AssertionError: assert 9 < 4
=============== 2 failed, 1 passed, 4 skipped in 0.15s  =============== 
```
which is obviously wrong.

This PR fix the above issue. The new output is

```bash
tests/test_foo.py::T::test_foo [custom message] (i=0) SUBSKIP (skip 0)
tests/test_foo.py::T::test_foo [custom message] (i=1) SUBSKIP (skip 1)
tests/test_foo.py::T::test_foo [custom message] (i=2) SUBSKIP (skip 2)
tests/test_foo.py::T::test_foo [custom message] (i=3) SUBSKIP (skip 3)
tests/test_foo.py::T::test_foo [custom message] (i=4) SUBFAIL
tests/test_foo.py::T::test_foo [custom message] (i=5) SUBFAIL
tests/test_foo.py::T::test_foo [custom message] (i=6) SUBFAIL
tests/test_foo.py::T::test_foo [custom message] (i=7) SUBFAIL
tests/test_foo.py::T::test_foo [custom message] (i=8) SUBFAIL
tests/test_foo.py::T::test_foo [custom message] (i=9) SUBFAIL
tests/test_foo.py::T::test_foo PASSED                                                                                                                                                                        
...
=============== short test summary info ===============
 [custom message] (i=4) SUBFAIL tests/test_foo.py::T::test_foo - AssertionError: assert 4 < 4
[custom message] (i=5) SUBFAIL tests/test_foo.py::T::test_foo - AssertionError: assert 5 < 4
[custom message] (i=6) SUBFAIL tests/test_foo.py::T::test_foo - AssertionError: assert 6 < 4
[custom message] (i=7) SUBFAIL tests/test_foo.py::T::test_foo - AssertionError: assert 7 < 4
[custom message] (i=8) SUBFAIL tests/test_foo.py::T::test_foo - AssertionError: assert 8 < 4
[custom message] (i=9) SUBFAIL tests/test_foo.py::T::test_foo - AssertionError: assert 9 < 4
=============== 6 failed, 1 passed, 4 skipped in 0.20s  =============== 
```

