### PR TITLE
Consistently use raw strings for line-matching regexes

### DIFF
--- a/tests/test_subtests.py
+++ b/tests/test_subtests.py
@@ -394,19 +394,19 @@ class TestSubTest:
             if sys.version_info < (3, 11):
                 result.stderr.re_match_lines(
                     [
-                        "FAIL: test_foo \(__main__\.T\) \[custom message\] \(i=4\).*",
-                        "FAIL: test_foo \(__main__\.T\) \[custom message\] \(i=9\).*",
-                        "Ran 1 test in .*",
-                        "FAILED \(failures=6, skipped=4\)",
+                        r"FAIL: test_foo \(__main__\.T\) \[custom message\] \(i=4\).*",
+                        r"FAIL: test_foo \(__main__\.T\) \[custom message\] \(i=9\).*",
+                        r"Ran 1 test in .*",
+                        r"FAILED \(failures=6, skipped=4\)",
                     ]
                 )
             else:
                 result.stderr.re_match_lines(
                     [
-                        "FAIL: test_foo \(__main__\.T\.test_foo\) \[custom message\] \(i=4\).*",
-                        "FAIL: test_foo \(__main__\.T\.test_foo\) \[custom message\] \(i=9\).*",
-                        "Ran 1 test in .*",
-                        "FAILED \(failures=6, skipped=4\)",
+                        r"FAIL: test_foo \(__main__\.T\.test_foo\) \[custom message\] \(i=4\).*",
+                        r"FAIL: test_foo \(__main__\.T\.test_foo\) \[custom message\] \(i=9\).*",
+                        r"Ran 1 test in .*",
+                        r"FAILED \(failures=6, skipped=4\)",
                     ]
                 )
         elif runner == "pytest-normal":
@@ -418,11 +418,11 @@ class TestSubTest:
                     r"test_skip_with_failure.py::T::test_foo \[custom message\] \(i=4\) SUBFAIL .*",
                     r"test_skip_with_failure.py::T::test_foo \[custom message\] \(i=9\) SUBFAIL .*",
                     "test_skip_with_failure.py::T::test_foo PASSED .*",
-                    "[custom message] (i=0) SUBSKIP [1] test_skip_with_failure.py:5: skip subtest i=0",
-                    "[custom message] (i=0) SUBSKIP [1] test_skip_with_failure.py:5: skip subtest i=3",
-                    "[custom message] (i=4) SUBFAIL test_skip_with_failure.py::T::test_foo - AssertionError: assert 4 < 4",
-                    "[custom message] (i=9) SUBFAIL test_skip_with_failure.py::T::test_foo - AssertionError: assert 9 < 4",
-                    ".* 6 failed, 1 passed, 4 skipped in .*",
+                    r"[custom message] (i=0) SUBSKIP [1] test_skip_with_failure.py:5: skip subtest i=0",
+                    r"[custom message] (i=0) SUBSKIP [1] test_skip_with_failure.py:5: skip subtest i=3",
+                    r"[custom message] (i=4) SUBFAIL test_skip_with_failure.py::T::test_foo - AssertionError: assert 4 < 4",
+                    r"[custom message] (i=9) SUBFAIL test_skip_with_failure.py::T::test_foo - AssertionError: assert 9 < 4",
+                    r".* 6 failed, 1 passed, 4 skipped in .*",
                 ]
             )
         else:
@@ -463,19 +463,19 @@ class TestSubTest:
             if sys.version_info < (3, 11):
                 result.stderr.re_match_lines(
                     [
-                        "FAIL: test_foo \(__main__\.T\) \[custom message\] \(i=4\).*",
-                        "FAIL: test_foo \(__main__\.T\) \[custom message\] \(i=9\).*",
-                        "Ran 1 test in .*",
-                        "FAILED \(failures=6, skipped=5\)",
+                        r"FAIL: test_foo \(__main__\.T\) \[custom message\] \(i=4\).*",
+                        r"FAIL: test_foo \(__main__\.T\) \[custom message\] \(i=9\).*",
+                        r"Ran 1 test in .*",
+                        r"FAILED \(failures=6, skipped=5\)",
                     ]
                 )
             else:
                 result.stderr.re_match_lines(
                     [
-                        "FAIL: test_foo \(__main__\.T\.test_foo\) \[custom message\] \(i=4\).*",
-                        "FAIL: test_foo \(__main__\.T\.test_foo\) \[custom message\] \(i=9\).*",
-                        "Ran 1 test in .*",
-                        "FAILED \(failures=6, skipped=5\)",
+                        r"FAIL: test_foo \(__main__\.T\.test_foo\) \[custom message\] \(i=4\).*",
+                        r"FAIL: test_foo \(__main__\.T\.test_foo\) \[custom message\] \(i=9\).*",
+                        r"Ran 1 test in .*",
+                        r"FAILED \(failures=6, skipped=5\)",
                     ]
                 )
         elif runner == "pytest-normal":


### PR DESCRIPTION
Fixes #176.

Not all of the strings that I changed to raw literals (`r""`) contain invalid escape sequences like `\(`, but it makes sense (and is less error-prone) to use raw literals for regex patterns across the board rather than picking and choosing based on the contents of the patterns.